### PR TITLE
add Dockerfile to build logos-core in a container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+Dockerfile
+.dockerignore
+plugins/**/vendor/*
+plugins/**/*.so
+plugins/build/*
+./**/CMakeCache.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM fedora:43
+FROM ubuntu:24.10
 
 ADD . /app
 
 WORKDIR /app
 
-RUN dnf install -y qt6-qtbase-devel 
-RUN dnf install -y git protobuf-compiler protobuf-devel which patchelf lsb_release cargo awk
+RUN apt-get update &&\
+    apt-get install -y qt6-base-dev protobuf-compiler patchelf  git protobuf-compiler which cargo mawk cmake build-essential lsb-release jq curl
 
 RUN git submodule update --init --recursive

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM fedora:43
+
+ADD . /app
+
+WORKDIR /app
+
+RUN dnf install -y qt6-qtbase-devel 
+RUN dnf install -y git protobuf-compiler protobuf-devel which patchelf lsb_release cargo awk
+
+RUN git submodule update --init --recursive

--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ Build Core only:
 ./run_core.sh build
 ```
 
+Build Container:
+
+```bash
+docker build -t logos-core .
+```
+
+Run Container:
+
+```bash
+docker run -it logos-core
+```
+
 ## Requirements
 
 - QT 6.4

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ Build Core only:
 ## Requirements
 
 - QT 6.4
+
+  Ubuntu
+  ```
+  apt-get install qt6-base-dev protobuf-compiler patchelf
+  ```
 - CMake
 
 For some plugins

--- a/plugins/waku/build_libwaku.sh
+++ b/plugins/waku/build_libwaku.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
+set -e
+
 # Set base directory
 SCRIPT_DIR="$(dirname "$0")"
+MAKE_J=${1:-2}
 NWAKU_DIR="$SCRIPT_DIR/vendor/nwaku"
 LIBWAKU_PATH="$SCRIPT_DIR/lib/libwaku.so"
 
@@ -21,7 +24,7 @@ if [ ! -f "$LIBWAKU_PATH" ]; then
 
     # Build libwaku
     echo "Running make libwaku..."
-    make libwaku
+    make -j${MAKE_J} libwaku
 
     # Copy libwaku.so to the lib directory
     cp build/libwaku.so "$LIBWAKU_PATH"


### PR DESCRIPTION
Add a basic Dockerfile to build a container with all dependencies where the Logos Core can be built

Currently this results in a broken state:

```
[100%] Built target chat
Fixing library paths for waku_plugin.so on Linux...
Copying plugin libraries to build plugins directory...
Looking for plugin libraries in plugins/build/plugins directory...
Copying plugin: plugins/build/plugins/calculator_plugin.so
Copying plugin: plugins/build/plugins/hello_world_plugin.so
Copying plugin: plugins/build/plugins/libwaku.so
Copying plugin: plugins/build/plugins/waku_plugin.so
Copying plugin: plugins/build/plugins/chat_plugin.so
Plugins built successfully.
Starting logoscore application...
Required dependency not loaded: "waku"
No metadata found for plugin: "/app/core/build/plugins/libwaku.so"
```

and I have no clue why @iurimatias :(

Once this is resolved, I can setup a GH action to perform the build on each push to the main