### PR TITLE
Chore/improve module proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ modules/waku_module/lib/libwaku.so
 **/node_modules/**
 examples/node_app_using_lib/plugins/*
 SDK/js/logos-api/lib/*
+.cache

--- a/SDK/cpp/module_proxy.cpp
+++ b/SDK/cpp/module_proxy.cpp
@@ -6,6 +6,131 @@
 #include <QJsonArray>
 #include <QStringList>
 
+// Helper macro to simplify method invocation with return types
+#define INVOKE_METHOD_WITH_RETURN(returnType, castType) \
+    do { \
+        castType* result = static_cast<castType*>(returnValue); \
+        switch (args.size()) { \
+            case 0: \
+                return QMetaObject::invokeMethod(module, methodNameCStr, Qt::DirectConnection, Q_RETURN_ARG(returnType, *result)); \
+            case 1: \
+                return QMetaObject::invokeMethod(module, methodNameCStr, Qt::DirectConnection, Q_RETURN_ARG(returnType, *result), scopedArgs[0].arg); \
+            case 2: \
+                return QMetaObject::invokeMethod(module, methodNameCStr, Qt::DirectConnection, Q_RETURN_ARG(returnType, *result), scopedArgs[0].arg, scopedArgs[1].arg); \
+            case 3: \
+                return QMetaObject::invokeMethod(module, methodNameCStr, Qt::DirectConnection, Q_RETURN_ARG(returnType, *result), scopedArgs[0].arg, scopedArgs[1].arg, scopedArgs[2].arg); \
+            case 4: \
+                return QMetaObject::invokeMethod(module, methodNameCStr, Qt::DirectConnection, Q_RETURN_ARG(returnType, *result), scopedArgs[0].arg, scopedArgs[1].arg, scopedArgs[2].arg, scopedArgs[3].arg); \
+            case 5: \
+                return QMetaObject::invokeMethod(module, methodNameCStr, Qt::DirectConnection, Q_RETURN_ARG(returnType, *result), scopedArgs[0].arg, scopedArgs[1].arg, scopedArgs[2].arg, scopedArgs[3].arg, scopedArgs[4].arg); \
+            default: \
+                qWarning() << "ModuleProxy: Currently supports 0-5 arguments. Got:" << args.size(); \
+                return false; \
+        } \
+    } while(0)
+
+namespace {
+    class ScopedQArg {
+    public:
+        ScopedQArg(QMetaMethodArgument a, std::function<void(const void*)> d)
+            : arg(a), deleter(std::move(d)) {}
+
+        ~ScopedQArg() {
+            if (deleter) {
+                deleter(arg.data);
+            }
+        }
+
+        ScopedQArg(ScopedQArg&&) = default;
+        ScopedQArg& operator=(ScopedQArg&&) = default;
+        ScopedQArg(const ScopedQArg&) = delete;
+        ScopedQArg& operator=(const ScopedQArg&) = delete;
+
+        QMetaMethodArgument arg;
+
+    private:
+        std::function<void(const void*)> deleter;
+    };
+
+    auto toScopedQArgs(const QVariantList& args)
+    {
+        auto scopedArgs = std::vector<ScopedQArg>{};
+        for (const auto& arg : args) {
+            switch (arg.typeId()) {
+                case QMetaType::Int: {
+                    auto value = new int{arg.toInt()};
+                    scopedArgs.emplace_back(
+                        Q_ARG(int, *value),
+                        [](const void* data) {
+                            delete static_cast<const int*>(data);
+                        }
+                    );
+                    break;
+                }
+                case QMetaType::QString:
+                default: {
+                    auto value = new QString{arg.toString()};
+                    scopedArgs.emplace_back(
+                        Q_ARG(QString, *value),
+                        [](const void* data) {
+                            delete static_cast<const QString*>(data);
+                        }
+                    );
+                    break;
+                }
+            }
+        }
+        return scopedArgs;
+    }
+
+    // Helper method to invoke methods with different return types and argument counts
+    bool invokeMethodByArgCount(QObject *module, const QString& methodName, const QVariantList& args, void* returnValue, const char* returnTypeName)
+    {
+        // Store the UTF-8 data to ensure it stays in scope
+        QByteArray methodNameBytes = methodName.toUtf8();
+        const char* methodNameCStr = methodNameBytes.constData();
+
+        auto scopedArgs = toScopedQArgs(args);
+
+        if (returnValue == nullptr) {
+            // Void method - no return value
+            switch (args.size()) {
+                case 0:
+                    return QMetaObject::invokeMethod(module, methodNameCStr, Qt::DirectConnection);
+                case 1:
+                    return QMetaObject::invokeMethod(module, methodNameCStr, Qt::DirectConnection, scopedArgs[0].arg);
+                case 2:
+                    return QMetaObject::invokeMethod(module, methodNameCStr, Qt::DirectConnection, scopedArgs[0].arg, scopedArgs[1].arg);
+                case 3:
+                    return QMetaObject::invokeMethod(module, methodNameCStr, Qt::DirectConnection, scopedArgs[0].arg, scopedArgs[1].arg, scopedArgs[2].arg);
+                case 4:
+                    return QMetaObject::invokeMethod(module, methodNameCStr, Qt::DirectConnection, scopedArgs[0].arg, scopedArgs[1].arg, scopedArgs[2].arg, scopedArgs[3].arg);
+                case 5:
+                    return QMetaObject::invokeMethod(module, methodNameCStr, Qt::DirectConnection, scopedArgs[0].arg, scopedArgs[1].arg, scopedArgs[2].arg, scopedArgs[3].arg, scopedArgs[4].arg);
+                default:
+                    qWarning() << "ModuleProxy: Currently supports 0-5 arguments. Got:" << args.size();
+                    return false;
+            }
+        } else if (strcmp(returnTypeName, "bool") == 0) {
+            qDebug() << "ModuleProxy: invokeMethodByArgCount - bool case with" << args.size() << "arguments";
+            INVOKE_METHOD_WITH_RETURN(bool, bool);
+        } else if (strcmp(returnTypeName, "int") == 0) {
+            INVOKE_METHOD_WITH_RETURN(int, int);
+        } else if (strcmp(returnTypeName, "QString") == 0) {
+            INVOKE_METHOD_WITH_RETURN(QString, QString);
+        } else if (strcmp(returnTypeName, "QVariant") == 0) {
+            INVOKE_METHOD_WITH_RETURN(QVariant, QVariant);
+        } else if (strcmp(returnTypeName, "QJsonArray") == 0) {
+            INVOKE_METHOD_WITH_RETURN(QJsonArray, QJsonArray);
+        } else if (strcmp(returnTypeName, "QStringList") == 0) {
+            INVOKE_METHOD_WITH_RETURN(QStringList, QStringList);
+        } else {
+            qWarning() << "ModuleProxy: Unsupported return type in invokeMethodByArgCount:" << returnTypeName;
+            return false;
+        }
+    }
+}
+
 ModuleProxy::ModuleProxy(QObject* module, QObject* parent)
     : QObject(parent)
     , m_module(module)
@@ -22,109 +147,6 @@ ModuleProxy::ModuleProxy(QObject* module, QObject* parent)
 ModuleProxy::~ModuleProxy()
 {
     qDebug() << "ModuleProxy: Destroyed for module:" << m_module;
-}
-
-// Helper function to create QGenericArgument from QVariant
-// Each call generates its own unique GUID for isolated argument storage
-// This is currently quite an ugly hack, need to review
-auto ModuleProxy::createArgument(const QVariant& variant)
-{
-    // Generate a unique GUID for this specific argument
-    QString argId = QUuid::createUuid().toString();
-    
-    switch (variant.typeId()) {
-        case QMetaType::QString: {
-            m_stringArgsStorage[argId].append(variant.toString());
-            qDebug() << "ModuleProxy: createArgument - creating QString arg with value:" << m_stringArgsStorage[argId].last() << "argId:" << argId;
-            return Q_ARG(QString, m_stringArgsStorage[argId].last());
-        }
-        case QMetaType::Int: {
-            m_intArgsStorage[argId].append(variant.toInt());
-            qDebug() << "ModuleProxy: createArgument - creating int arg with value:" << m_intArgsStorage[argId].last() << "argId:" << argId;
-            return Q_ARG(int, m_intArgsStorage[argId].last());
-        }
-        default: {
-            // For other types, try to convert to string as fallback
-            m_stringArgsStorage[argId].append(variant.toString());
-            qDebug() << "ModuleProxy: createArgument - converting to QString arg with value:" << m_stringArgsStorage[argId].last() << "argId:" << argId;
-            return Q_ARG(QString, m_stringArgsStorage[argId].last());
-        }
-    }
-}
-
-// Helper macro to simplify method invocation with return types
-#define INVOKE_METHOD_WITH_RETURN(returnType, castType) \
-    do { \
-        castType* result = static_cast<castType*>(returnValue); \
-        switch (args.size()) { \
-            case 0: \
-                return QMetaObject::invokeMethod(m_module, methodNameCStr, Qt::DirectConnection, Q_RETURN_ARG(returnType, *result)); \
-            case 1: \
-                return QMetaObject::invokeMethod(m_module, methodNameCStr, Qt::DirectConnection, Q_RETURN_ARG(returnType, *result), createArgument(args[0])); \
-            case 2: \
-                return QMetaObject::invokeMethod(m_module, methodNameCStr, Qt::DirectConnection, Q_RETURN_ARG(returnType, *result), createArgument(args[0]), createArgument(args[1])); \
-            case 3: \
-                return QMetaObject::invokeMethod(m_module, methodNameCStr, Qt::DirectConnection, Q_RETURN_ARG(returnType, *result), createArgument(args[0]), createArgument(args[1]), createArgument(args[2])); \
-            case 4: \
-                return QMetaObject::invokeMethod(m_module, methodNameCStr, Qt::DirectConnection, Q_RETURN_ARG(returnType, *result), createArgument(args[0]), createArgument(args[1]), createArgument(args[2]), createArgument(args[3])); \
-            case 5: \
-                return QMetaObject::invokeMethod(m_module, methodNameCStr, Qt::DirectConnection, Q_RETURN_ARG(returnType, *result), createArgument(args[0]), createArgument(args[1]), createArgument(args[2]), createArgument(args[3]), createArgument(args[4])); \
-            default: \
-                qWarning() << "ModuleProxy: Currently supports 0-5 arguments. Got:" << args.size(); \
-                return false; \
-        } \
-    } while(0)
-
-// Helper method to invoke methods with different return types and argument counts
-bool ModuleProxy::invokeMethodByArgCount(const QString& methodName, const QVariantList& args, void* returnValue, const char* returnTypeName)
-{
-    // Store the UTF-8 data to ensure it stays in scope
-    QByteArray methodNameBytes = methodName.toUtf8();
-    const char* methodNameCStr = methodNameBytes.constData();
-
-    if (returnValue == nullptr) {
-        // Void method - no return value
-        switch (args.size()) {
-            case 0:
-                return QMetaObject::invokeMethod(m_module, methodNameCStr, Qt::DirectConnection);
-            case 1:
-                return QMetaObject::invokeMethod(m_module, methodNameCStr, Qt::DirectConnection, createArgument(args[0]));
-            case 2:
-                return QMetaObject::invokeMethod(m_module, methodNameCStr, Qt::DirectConnection, createArgument(args[0]), createArgument(args[1]));
-            case 3: {
-                auto arg0 = createArgument(args[0]);
-                auto arg1 = createArgument(args[1]);
-                auto arg2 = createArgument(args[2]);
-                qDebug() << "ModuleProxy: Argument 0:" << args[0];
-                qDebug() << "ModuleProxy: Argument 1:" << args[1]; 
-                qDebug() << "ModuleProxy: Argument 2:" << args[2];
-                return QMetaObject::invokeMethod(m_module, methodNameCStr, Qt::DirectConnection, arg0, arg1, arg2);
-            }
-            case 4:
-                return QMetaObject::invokeMethod(m_module, methodNameCStr, Qt::DirectConnection, createArgument(args[0]), createArgument(args[1]), createArgument(args[2]), createArgument(args[3]));
-            case 5:
-                return QMetaObject::invokeMethod(m_module, methodNameCStr, Qt::DirectConnection, createArgument(args[0]), createArgument(args[1]), createArgument(args[2]), createArgument(args[3]), createArgument(args[4]));
-            default:
-                qWarning() << "ModuleProxy: Currently supports 0-5 arguments. Got:" << args.size();
-                return false;
-        }
-    } else if (strcmp(returnTypeName, "bool") == 0) {
-        qDebug() << "ModuleProxy: invokeMethodByArgCount - bool case with" << args.size() << "arguments";
-        INVOKE_METHOD_WITH_RETURN(bool, bool);
-    } else if (strcmp(returnTypeName, "int") == 0) {
-        INVOKE_METHOD_WITH_RETURN(int, int);
-    } else if (strcmp(returnTypeName, "QString") == 0) {
-        INVOKE_METHOD_WITH_RETURN(QString, QString);
-    } else if (strcmp(returnTypeName, "QVariant") == 0) {
-        INVOKE_METHOD_WITH_RETURN(QVariant, QVariant);
-    } else if (strcmp(returnTypeName, "QJsonArray") == 0) {
-        INVOKE_METHOD_WITH_RETURN(QJsonArray, QJsonArray);
-    } else if (strcmp(returnTypeName, "QStringList") == 0) {
-        INVOKE_METHOD_WITH_RETURN(QStringList, QStringList);
-    } else {
-        qWarning() << "ModuleProxy: Unsupported return type in invokeMethodByArgCount:" << returnTypeName;
-        return false;
-    }
 }
 
 QVariant ModuleProxy::callRemoteMethod(const QString& methodName, const QVariantList& args)
@@ -146,16 +168,16 @@ QVariant ModuleProxy::callRemoteMethod(const QString& methodName, const QVariant
     // Find the method to get its return type
     const QMetaObject* metaObject = m_module->metaObject();
     int methodIndex = -1;
-    
+
     qDebug() << "ModuleProxy: Looking for method" << methodName << "with" << args.size() << "arguments";
     qDebug() << "ModuleProxy: Available methods in" << metaObject->className() << ":";
-    
+
     // Debug: List all available methods
     for (int i = 0; i < metaObject->methodCount(); ++i) {
         QMetaMethod method = metaObject->method(i);
         qDebug() << "  Method" << i << ":" << method.name() << "with" << method.parameterCount() << "parameters, return type:" << method.returnMetaType().name();
     }
-    
+
     // Find the method with matching name and argument count
     for (int i = 0; i < metaObject->methodCount(); ++i) {
         QMetaMethod method = metaObject->method(i);
@@ -165,28 +187,28 @@ QVariant ModuleProxy::callRemoteMethod(const QString& methodName, const QVariant
             break;
         }
     }
-    
+
     if (methodIndex == -1) {
         qWarning() << "ModuleProxy: Method not found:" << methodName << "with" << args.size() << "arguments";
         return QVariant();
     }
-    
+
     QMetaMethod method = metaObject->method(methodIndex);
     QMetaType returnType = method.returnMetaType();
-    
+
     qDebug() << "ModuleProxy: Method signature:" << method.methodSignature();
     qDebug() << "ModuleProxy: Parameter types:";
     for (int i = 0; i < method.parameterCount(); ++i) {
         qDebug() << "  Param" << i << ":" << method.parameterMetaType(i).name();
     }
-    
+
     // Handle different return types
     bool success = false;
     QVariant result;
-    
+
     if (returnType == QMetaType::fromType<void>()) {
         // Void method - no return value expected
-        success = invokeMethodByArgCount(methodName, args, nullptr, nullptr);
+        success = invokeMethodByArgCount(m_module, methodName, args, nullptr, nullptr);
         if (success) {
             result = QVariant(true); // Return true to indicate success
         }
@@ -194,7 +216,7 @@ QVariant ModuleProxy::callRemoteMethod(const QString& methodName, const QVariant
         // Bool return type
         qDebug() << "ModuleProxy: Invoking bool method" << methodName;
         bool boolResult = false;
-        success = invokeMethodByArgCount(methodName, args, &boolResult, "bool");
+        success = invokeMethodByArgCount(m_module, methodName, args, &boolResult, "bool");
         qDebug() << "ModuleProxy: Bool method invocation result:" << success << "value:" << boolResult;
         if (success) {
             result = QVariant(boolResult);
@@ -202,21 +224,21 @@ QVariant ModuleProxy::callRemoteMethod(const QString& methodName, const QVariant
     } else if (returnType == QMetaType::fromType<int>()) {
         // Int return type
         int intResult = 0;
-        success = invokeMethodByArgCount(methodName, args, &intResult, "int");
+        success = invokeMethodByArgCount(m_module, methodName, args, &intResult, "int");
         if (success) {
             result = QVariant(intResult);
         }
     } else if (returnType == QMetaType::fromType<QString>()) {
         // QString return type
         QString stringResult;
-        success = invokeMethodByArgCount(methodName, args, &stringResult, "QString");
+        success = invokeMethodByArgCount(m_module, methodName, args, &stringResult, "QString");
         if (success) {
             result = QVariant(stringResult);
         }
     } else if (returnType == QMetaType::fromType<QVariant>()) {
         // QVariant return type
         QVariant variantResult;
-        success = invokeMethodByArgCount(methodName, args, &variantResult, "QVariant");
+        success = invokeMethodByArgCount(m_module, methodName, args, &variantResult, "QVariant");
         if (success) {
             result = variantResult;
         }
@@ -224,7 +246,7 @@ QVariant ModuleProxy::callRemoteMethod(const QString& methodName, const QVariant
         // QJsonArray return type
         qDebug() << "ModuleProxy: Invoking QJsonArray method" << methodName;
         QJsonArray jsonArrayResult;
-        success = invokeMethodByArgCount(methodName, args, &jsonArrayResult, "QJsonArray");
+        success = invokeMethodByArgCount(m_module, methodName, args, &jsonArrayResult, "QJsonArray");
         qDebug() << "ModuleProxy: QJsonArray method invocation result:" << success << "array size:" << jsonArrayResult.size();
         if (success) {
             result = QVariant(jsonArrayResult);
@@ -233,7 +255,7 @@ QVariant ModuleProxy::callRemoteMethod(const QString& methodName, const QVariant
         // QStringList return type
         qDebug() << "ModuleProxy: Invoking QStringList method" << methodName;
         QStringList stringListResult;
-        success = invokeMethodByArgCount(methodName, args, &stringListResult, "QStringList");
+        success = invokeMethodByArgCount(m_module, methodName, args, &stringListResult, "QStringList");
         qDebug() << "ModuleProxy: QStringList method invocation result:" << success << "list size:" << stringListResult.size();
         if (success) {
             result = QVariant(stringListResult);
@@ -254,4 +276,4 @@ QVariant ModuleProxy::callRemoteMethod(const QString& methodName, const QVariant
 }
 
 // Include MOC for template instantiation
-#include "moc_module_proxy.cpp" 
+#include "moc_module_proxy.cpp"

--- a/SDK/cpp/module_proxy.cpp
+++ b/SDK/cpp/module_proxy.cpp
@@ -36,9 +36,9 @@ namespace {
             : arg(a), deleter(std::move(d)) {}
 
         ~ScopedQArg() {
-            if (deleter) {
-                deleter(arg.data);
-            }
+            // if (deleter) {
+            //     deleter(arg.data);
+            // }
         }
 
         ScopedQArg(ScopedQArg&&) = default;

--- a/SDK/cpp/module_proxy.cpp
+++ b/SDK/cpp/module_proxy.cpp
@@ -36,13 +36,16 @@ namespace {
             : arg(a), deleter(std::move(d)) {}
 
         ~ScopedQArg() {
-            // if (deleter) {
-            //     deleter(arg.data);
-            // }
+            if (deleter) {
+                deleter(arg.data);
+            }
         }
 
-        ScopedQArg(ScopedQArg&&) = default;
-        ScopedQArg& operator=(ScopedQArg&&) = default;
+        ScopedQArg(ScopedQArg&& other)
+            : arg(std::move(other.arg)), deleter(std::move(other.deleter)) {
+                other.deleter = nullptr;
+        }
+        ScopedQArg& operator=(ScopedQArg&&) = delete;
         ScopedQArg(const ScopedQArg&) = delete;
         ScopedQArg& operator=(const ScopedQArg&) = delete;
 

--- a/SDK/cpp/module_proxy.h
+++ b/SDK/cpp/module_proxy.h
@@ -10,7 +10,7 @@
 
 /**
  * @brief ModuleProxy provides a proxy interface for module interactions
- * 
+ *
  * This class serves as a proxy layer for communicating with modules
  * in the Logos Core system.
  */
@@ -44,34 +44,6 @@ signals:
 
 private:
     QObject* m_module;
-    
-    // Storage for string arguments to keep them alive during method calls
-    // Key: GUID for method call, Value: list of string arguments for that call
-    // This is currently quite an ugly hack, need to review
-    mutable QHash<QString, QList<QString>> m_stringArgsStorage;
-    
-    // Storage for int arguments to keep them alive during method calls
-    // This is currently quite an ugly hack, need to review
-    mutable QHash<QString, QList<int>> m_intArgsStorage;
-
-    /**
-     * @brief Helper function to create QGenericArgument from QVariant
-     * @param variant The QVariant to convert
-     * @return QGenericArgument that can be used with QMetaObject::invokeMethod
-     * 
-     * @note Each call generates its own unique GUID for isolated argument storage
-     */
-    auto createArgument(const QVariant& variant);
-
-    /**
-     * @brief Helper method to invoke methods with different return types and argument counts
-     * @param methodName The name of the method to call
-     * @param args Arguments to pass to the method
-     * @param returnValue Pointer to store the return value (nullptr for void methods)
-     * @param returnTypeName String name of the return type ("bool", "int", "QString", "QVariant", etc.)
-     * @return true if the method call succeeded, false otherwise
-     */
-    bool invokeMethodByArgCount(const QString& methodName, const QVariantList& args, void* returnValue, const char* returnTypeName);
 };
 
-#endif // MODULE_PROXY_H 
+#endif // MODULE_PROXY_H

--- a/tests/test_simple/run_test_simple.sh
+++ b/tests/test_simple/run_test_simple.sh
@@ -20,7 +20,7 @@ if [ -d "build" ]; then
 fi
 mkdir -p build
 cd build
-cmake ..
+cmake -DCMAKE_BUILD_TYPE=Debug ..
 if command -v nproc >/dev/null 2>&1; then
     JOBS=$(nproc)
 elif command -v sysctl >/dev/null 2>&1; then
@@ -40,7 +40,7 @@ if [ -d "build" ]; then
 fi
 mkdir -p build
 cd build
-cmake ..
+cmake -DCMAKE_BUILD_TYPE=Debug ..
 make -j$JOBS template_module_plugin
 echo "Template module build completed!"
 
@@ -53,7 +53,7 @@ cd build
 
 # Configure with CMake
 echo "Configuring with CMake..."
-cmake ..
+cmake -DCMAKE_BUILD_TYPE=Debug ..
 
 # Build the application
 echo "Building test_simple application..."
@@ -127,4 +127,4 @@ echo "Running Test Simple application..."
 echo "Press Ctrl+C to stop the application."
 echo "=================================="
 cd bin
-./test_simple 
+./test_simple


### PR DESCRIPTION
simplify module_proxy's Q_ARGs management

Instead of storing Q_ARG values in `ModuleProxy`'s cache, wrap them in `ScopedQArg`, which frees the memory when going out of scope.